### PR TITLE
Fix in-range?

### DIFF
--- a/src/rewrite_clj/zip/findz.cljs
+++ b/src/rewrite_clj/zip/findz.cljs
@@ -18,13 +18,10 @@
 
 
 (defn in-range? [{:keys [row col end-row end-col]} {r :row c :col}]
-  (cond
-   (or  (> row r) (> r end-row)) false
-   (and (> r row) (> end-row r)) true
-   (and (>= c col) (> end-col c)) true
-   (and (= r row) (> end-row r) (>= c col)) true
-   (and (= r end-row) (> end-row r) (>= col c)) true
-   :else false))
+  (and (>= r row)
+       (<= r end-row)
+       (if (= r row) (>= c col) true)
+       (if (= r end-row) (<= c end-col) true)))
 
 
 ;; ## Find Operations


### PR DESCRIPTION
Current version fails when c and end-col are equal. Eg/ 
(= false (in-range? {:row 1 :col 10 :end-row 2 :col 10} {:row 2 :col 5})).
