### PR TITLE
Upgrade to tools.reader 1.0.5, fix broken call to read-token (Issue #11)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.228"
                   :exclusions [org.apache.ant/ant]]
-                 [org.clojure/tools.reader "1.0.0-alpha3"]]
+                 [org.clojure/tools.reader "1.0.5"]]
   :doo {:build "test"}
   :profiles {:dev
              {:plugins [[lein-cljsbuild "1.1.2"]

--- a/src/rewrite_clj/reader.cljs
+++ b/src/rewrite_clj/reader.cljs
@@ -6,7 +6,6 @@
             [goog.string :as gstring]
             [rewrite-clj.node.protocols :as nd]))
 
-(def reader-error reader-types/reader-error)
 (def read-char reader-types/read-char)
 (def get-column-number reader-types/get-column-number)
 (def get-line-number reader-types/get-line-number)
@@ -179,7 +178,7 @@
 
 (defn read-keyword
   [^not-native reader initch]
-  (let [tok (cljs.tools.reader/read-token reader (read-char reader))
+  (let [tok (cljs.tools.reader/read-token reader :keyword (read-char reader))
         a (re-matches* (re-pattern "^[:]?([^0-9/].*/)?([^0-9/][^/]*)$") tok)
         token (aget a 0)
         ns (aget a 1)
@@ -188,7 +187,9 @@
                  (identical? (. ns (substring (- (.-length ns) 2) (.-length ns))) ":/"))
             (identical? (aget name (dec (.-length name))) ":")
             (not (== (.indexOf token "::" 1) -1)))
-      (reader-error reader "Invalid token: " token)
+      (cljs.tools.reader.impl.errors/reader-error reader 
+                                                  "Invalid token: " 
+						  token)
       (if (and (not (nil? ns)) (> (.-length ns) 0))
         (keyword (.substring ns 0 (.indexOf ns "/")) name)
         (keyword (.substring token 1))))))


### PR DESCRIPTION
I managed to get the tests to run successfully in my fork, and then I upgraded to tools.reader 1.0.5, and I got 13 errors.  After fixing the problem in read-keyword, the tests now run successfully.  In addition, my use of rewrite-cljs confirms that it seems to be working correctly with this fix.  Accepting this change will allow use of rewrite-cljs in both `lumo` and `planck`, for what that is worth.